### PR TITLE
tmp_install_packages temp library is now inserted properly

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+* Bugfix - tmp_install_packages no longer overwrites libraries which are not 
+  the base and user libraries.
 * New function: tmp_install_packages - installs packages to a temporary library.
 * Bugfix - readSO now works on Mac.
 

--- a/R/tmp_install_packages.R
+++ b/R/tmp_install_packages.R
@@ -38,7 +38,8 @@ tmp_install_packages <- function(package, dependencies=TRUE, ...) {
   ## this session would be installed into 'path'
   if (!(path %in% .libPaths())) {
     firstpath <- .libPaths()[1]
-    .libPaths(c(firstpath, path))
+    otherpaths <- .libPaths()[-1]
+    .libPaths(c(firstpath, path, otherpaths))
   }
   install.packages(package, dependencies=dependencies, lib=path, ...)
 }


### PR DESCRIPTION
As detailed in #8, if there are additional libraries to the user and base libraries, they will be replaced. This prevents that from happening by explicitly ensuring they remain in the libpath.
